### PR TITLE
touch files, because of docker filesystem problem

### DIFF
--- a/dockerfiles/ilias-transientmysql/resources/entrypoint.sh
+++ b/dockerfiles/ilias-transientmysql/resources/entrypoint.sh
@@ -4,7 +4,12 @@ if [ "$remotemysql" = "yes" ]; then
 	sed -i "s|bind-address.*= 127.0.0.1|bind-address = 0.0.0.0|g" /etc/mysql/my.cnf
 fi
 
-service mysql restart
+# touch files, because of docker filesystem problem
+# see https://github.com/docker/for-linux/issues/72
+find /var/lib/mysql -type f -exec touch {} \;
+
+service mysql start
+
 mysqladmin -u root -p password "$containermysql_rootpw" --host=127.0.0.1 --password=""
 
 #/data/resources/transientmysql/createiliasdump.sh --target /opt/w.zip


### PR DESCRIPTION
Hi @tikiatua 
this should fix #1 

You can try it with `whiledo/ilias-transientmysql:mysql-fix`

It was a docker filesystem problem. See also https://github.com/docker/for-linux/issues/72